### PR TITLE
Fixed saveSwitchingTable and loadSwitchingTable

### DIFF
--- a/src/main/java/edu/whu/tmdb/storage/memory/MemManager.java
+++ b/src/main/java/edu/whu/tmdb/storage/memory/MemManager.java
@@ -595,6 +595,7 @@ public class MemManager {
         File f = new File(Constant.SYSTEM_TABLE_DIR + "ot");
         FileOperation.createNewFile(f);
         RandomAccessFile raf = new RandomAccessFile(f, "rw");
+        raf.setLength(0);
 
         // 用int记录maxTupleId
         raf.writeInt(this.objectTable.maxTupleId);

--- a/src/main/java/edu/whu/tmdb/storage/memory/MemManager.java
+++ b/src/main/java/edu/whu/tmdb/storage/memory/MemManager.java
@@ -517,6 +517,12 @@ public class MemManager {
             // 存deputyattrid
             writeAccess.write(Constant.INT_TO_BYTES(item.deputyAttrId));
             // writeAccess.write(item.deputy.getBytes());
+            // 存oriAttr，先存储长度，再存储数据
+            writeAccess.write(Constant.INT_TO_BYTES(item.oriAttr.length()));
+            writeAccess.write(item.oriAttr.getBytes());
+            // 存deputyAttr，先存储长度，再存储数据
+            writeAccess.write(Constant.INT_TO_BYTES(item.deputyAttr.length()));
+            writeAccess.write(item.deputyAttr.getBytes());
             // 存rule，先存储长度，再存储数据
             writeAccess.write(Constant.INT_TO_BYTES(item.rule.length()));
             writeAccess.write(item.rule.getBytes());
@@ -552,10 +558,26 @@ public class MemManager {
             item.deputyAttrId = raf.readInt();
             cur += Integer.BYTES;
 
+            // 读oriAttr
+            int bufferLength = raf.readInt();
+            cur += Integer.BYTES;
+            byte[] buffer = new byte[bufferLength];
+            raf.read(buffer);
+            cur += bufferLength;
+            item.oriAttr = new String(buffer);
+
+            // 读deputyAttr
+            bufferLength = raf.readInt();
+            cur += Integer.BYTES;
+            buffer = new byte[bufferLength];
+            raf.read(buffer);
+            cur += bufferLength;
+            item.deputyAttr = new String(buffer);
+
             // 读rule
             int ruleLength = raf.readInt();
             cur += Integer.BYTES;
-            byte[] buffer = new byte[ruleLength];
+            buffer = new byte[ruleLength];
             raf.read(buffer);
             cur += ruleLength;
             item.rule = new String(buffer);


### PR DESCRIPTION
原先存储和读取 SwitchingTable 时没有涉及oriAttr 和 deputyAttr，因此修改了 saveSwitchingTable 和 loadSwitchingTable
原先存储 ObjectTable 时，没有将原文件清空就进行存储，导致新的 ObjectTable 长度小于旧的时，旧的表不能被完全覆盖
